### PR TITLE
fix(order-management): upd Prisma import path

### DIFF
--- a/src/order-management/infraestructure/order.repository.ts
+++ b/src/order-management/infraestructure/order.repository.ts
@@ -1,6 +1,6 @@
 import { IOrderRepository } from '../domain/interfaces/order.interface';
 import { Order } from '../domain/order';
-import prisma from '../../../dist/prisma/index';
+import prisma from '../../../prisma/index';
 
 export class OrderRepositoryPrismaSqlite implements IOrderRepository {
   public async addOrder(order: Order): Promise<Order> {


### PR DESCRIPTION
Se cambia la ruta de importación hacia la correcta ubicación de la instancia singleton de `PrismaClient`.

Solves #3 
